### PR TITLE
Potential fix for code scanning alert no. 47: Database query built from user-controlled sources

### DIFF
--- a/witness_proof.js
+++ b/witness_proof.js
@@ -103,7 +103,7 @@ function prepareWitnessProof(arrWitnesses, last_stable_mci, handleResult){
 			});
 		},
 		function(cb){ // add definition changes and new definitions of witnesses
-			var after_last_stable_mci_cond = (last_stable_mci > 0) ? "latest_included_mc_index>="+last_stable_mci : "1";
+			var after_last_stable_mci_cond = (last_stable_mci > 0) ? "latest_included_mc_index >= ?" : "1=1";
 			db.query(
 				/*"SELECT DISTINCT units.unit \n\
 				FROM unit_authors \n\
@@ -133,7 +133,7 @@ function prepareWitnessProof(arrWitnesses, last_stable_mci, handleResult){
 				CROSS JOIN units ON unit_authors.unit=units.unit \n\
 				WHERE address_definition_changes.address IN(?) AND "+after_last_stable_mci_cond+" AND is_stable=1 AND sequence='good' \n\
 				ORDER BY `level`", 
-				[arrWitnesses, arrWitnesses, arrWitnesses],
+				[arrWitnesses, arrWitnesses, arrWitnesses, last_stable_mci > 0 ? last_stable_mci : undefined],
 				function(rows){
 					async.eachSeries(rows, function(row, cb2){
 						storage.readJoint(db, row.unit, {


### PR DESCRIPTION
Potential fix for [https://github.com/codeallthethingsbreak/ocore/security/code-scanning/47](https://github.com/codeallthethingsbreak/ocore/security/code-scanning/47)

To fix the issue, we need to ensure that user-controlled input is safely embedded into the SQL query. This can be achieved by using parameterized queries or prepared statements, which prevent SQL injection by treating user input as data rather than executable code.

In this case, the `after_last_stable_mci_cond` condition should be rewritten to use a query parameter instead of string concatenation. This involves:
1. Modifying the SQL query to include a placeholder for the `last_stable_mci` value.
2. Passing the `last_stable_mci` value as a parameter to the query execution function.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
